### PR TITLE
feat: expose Arc<serde_json::Value> from package.json for Rspack

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -32,10 +32,19 @@ pub struct CachedFS {
 
 pub type CachedMap<T> = DashMap<PathBuf, CachedEntry<T>, BuildHasherDefault<FxHasher>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CachedEntry<T: Sized> {
     content: Arc<T>,
     stat: EntryStat,
+}
+
+impl<T> Clone for CachedEntry<T> {
+    fn clone(&self) -> Self {
+        Self {
+            content: Arc::clone(&self.content),
+            stat: self.stat,
+        }
+    }
 }
 
 impl<T: Sized> CachedEntry<T> {


### PR DESCRIPTION
See
* https://github.com/web-infra-dev/rspack/pull/3982

serde_json::Value can be exposed because it is a common value type, `DescriptionData` is an internal data strucutre, which should not be exposed.